### PR TITLE
Fix/55 uncaught exception gcs backup config

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,11 +417,13 @@ One must set the below fields when choosing the `BigQuery Snapshot` or `Both` ba
 One must set the below fields when choosing the `GCS Snapshot` or `Both` backup method:
 
 
-| Field                   | Description                                                                                  |
-|-------------------------|----------------------------------------------------------------------------------------------|
-| `gcs_snapshot_storage_location` | A GCS bucket in the format `gs://bucket/path/` to store snapshots to.                        |
-| `gcs_snapshot_format`           | The file format and compression used to export a BigQuery table to GCS. Avaiable values are `CSV`, `CSV_GZIP`, `JSON`, `JSON_GZIP`, `AVRO`, `AVRO_DEFLATE`, `AVRO_SNAPPY`, `PARQUET`, `PARQUET_SNAPPY`, `PARQUET_GZIP` |
-| `gcs_avro_use_logical_types`    | When set to `FALSE` the below BigQuery types are exported as strings, otherwise as their corresponding [Avro logical type](https://avro.apache.org/docs/1.10.2/spec.html#Logical+Types).    | 
+| Field                           | Description                                                                                                                                                                                                                                          |
+|---------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `gcs_snapshot_storage_location` | A GCS bucket in the format `gs://bucket/path/` to store snapshots to.                                                                                                                                                                                |
+| `gcs_snapshot_format`           | The file format and compression used to export a BigQuery table to GCS. Avaiable values are `CSV`, `CSV_GZIP`, `JSON`, `JSON_GZIP`, `AVRO`, `AVRO_DEFLATE`, `AVRO_SNAPPY`, `PARQUET`, `PARQUET_SNAPPY`, `PARQUET_GZIP`                               |
+| `gcs_avro_use_logical_types`    | Required when the `gcs_snapshot_format` is any Avro-format. When set to `FALSE` the below BigQuery types are exported as strings, otherwise as their corresponding [Avro logical type](https://avro.apache.org/docs/1.10.2/spec.html#Logical+Types). |
+| `gcs_csv_delimiter`             | Required when the `gcs_snapshot_format` is any CSV-format. Set the delimiter used for the exported CSV file(s). For example `;` or `,`                                                                                                               |`.                                                                                                                                                |`                                                                                                                                                |
+| `gcs_csv_export_header`         | Required when the `gcs_snapshot_format` is any CSV-format. Set to `TRUE` to include column headers in the exported CSV file(s). Otherwise set it to `FALSE`                                                                                          |
 
 BigQuery Types to Avro Logical Types mapping:
 

--- a/services/configurator-app/src/main/java/com/google/cloud/pso/bq_snapshot_manager/configurator/ConfiguratorController.java
+++ b/services/configurator-app/src/main/java/com/google/cloud/pso/bq_snapshot_manager/configurator/ConfiguratorController.java
@@ -17,7 +17,6 @@
  */
 package com.google.cloud.pso.bq_snapshot_manager.configurator;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.cloud.Tuple;
 import com.google.cloud.pso.bq_snapshot_manager.entities.NonRetryableApplicationException;
 import com.google.cloud.pso.bq_snapshot_manager.entities.PubSubEvent;
@@ -28,9 +27,9 @@ import com.google.cloud.pso.bq_snapshot_manager.functions.f02_configurator.Confi
 import com.google.cloud.pso.bq_snapshot_manager.helpers.ControllerExceptionHelper;
 import com.google.cloud.pso.bq_snapshot_manager.helpers.LoggingHelper;
 import com.google.cloud.pso.bq_snapshot_manager.helpers.TrackingHelper;
+import com.google.cloud.pso.bq_snapshot_manager.services.backup_policy.BackupPolicyService;
 import com.google.cloud.pso.bq_snapshot_manager.services.backup_policy.BackupPolicyServiceGCSImpl;
 import com.google.cloud.pso.bq_snapshot_manager.services.bq.BigQueryServiceImpl;
-import com.google.cloud.pso.bq_snapshot_manager.services.backup_policy.BackupPolicyService;
 import com.google.cloud.pso.bq_snapshot_manager.services.pubsub.PubSubServiceImpl;
 import com.google.cloud.pso.bq_snapshot_manager.services.scan.ResourceScannerImpl;
 import com.google.cloud.pso.bq_snapshot_manager.services.set.GCSPersistentSetImpl;
@@ -48,135 +47,141 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class ConfiguratorController {
 
-    private final LoggingHelper logger;
+  private final LoggingHelper logger;
 
-    private static final Integer functionNumber = 2;
+  private static final Integer functionNumber = 2;
 
-    private Gson gson;
-    private Environment environment;
-    private FallbackBackupPolicy fallbackBackupPolicy;
-    private String trackingId = TrackingHelper.MIN_RUN_ID;
+  private Gson gson;
+  private Environment environment;
+  private FallbackBackupPolicy fallbackBackupPolicy;
+  private String trackingId = TrackingHelper.MIN_RUN_ID;
 
-    public ConfiguratorController() throws JsonProcessingException {
+  public ConfiguratorController() throws NonRetryableApplicationException {
 
-        gson = new Gson();
-        environment = new Environment();
-        logger = new LoggingHelper(
-                ConfiguratorController.class.getSimpleName(),
-                functionNumber,
-                environment.getProjectId(),
-                environment.getApplicationName()
-        );
+    gson = new Gson();
+    environment = new Environment();
+    logger =
+        new LoggingHelper(
+            ConfiguratorController.class.getSimpleName(),
+            functionNumber,
+            environment.getProjectId(),
+            environment.getApplicationName());
 
-        logger.logInfoWithTracker(
-                trackingId,
-                null,
-                "Will try to parse fallback backup policy.."
-        );
+    logger.logInfoWithTracker(trackingId, null, "Will try to parse fallback backup policy..");
 
-        // initializing in the constructor to fail the Cloud Run deployment
-        // if the parsing failed. This is to avoid running the
-        // solution silently with invalid cofiguration
-        fallbackBackupPolicy = FallbackBackupPolicy.fromJson(environment.getBackupPolicyJson());
+    // initializing in the constructor to fail the Cloud Run deployment
+    // if the parsing failed. This is to avoid running the
+    // solution silently with invalid fallback configuration that fails during runtime
 
-        logger.logInfoWithTracker(
-                trackingId,
-                null,
-                "Successfully parsed fallback backup policy"
-        );
+    try {
+      fallbackBackupPolicy = FallbackBackupPolicy.fromJson(environment.getBackupPolicyJson());
+    } catch (Exception ex) {
+      String msg =
+          String.format(
+              "Failed to parse one or more fallback backup policies. %s", ex.getMessage());
+      logger.logSevereWithTracker(trackingId, null, msg);
+      throw new NonRetryableApplicationException(msg);
     }
 
-    @RequestMapping(value = "/", method = RequestMethod.POST)
-    public ResponseEntity receiveMessage(@RequestBody PubSubEvent requestBody) {
+    logger.logInfoWithTracker(trackingId, null, "Successfully parsed fallback backup policy");
+  }
 
+  @RequestMapping(value = "/", method = RequestMethod.POST)
+  public ResponseEntity receiveMessage(@RequestBody PubSubEvent requestBody) {
 
-        BackupPolicyService backupPolicyService = null;
+    BackupPolicyService backupPolicyService = null;
 
-        // These values will be updated based on the execution flow and logged at the end
-        ResponseEntity responseEntity;
-        ConfiguratorRequest configuratorRequest = null;
-        ConfiguratorResponse configuratorResponse = null;
-        boolean isSuccess;
-        Exception error = null;
-        boolean isRetryableError= false;
+    // These values will be updated based on the execution flow and logged at the end
+    ResponseEntity responseEntity;
+    ConfiguratorRequest configuratorRequest = null;
+    ConfiguratorResponse configuratorResponse = null;
+    boolean isSuccess;
+    Exception error = null;
+    boolean isRetryableError = false;
 
-        try {
+    try {
 
-            if (requestBody == null || requestBody.getMessage() == null) {
-                String msg = "Bad Request: invalid message format";
-                logger.logSevereWithTracker(trackingId,null, msg);
-                throw new NonRetryableApplicationException("Request body or message is Null.");
-            }
+      if (requestBody == null || requestBody.getMessage() == null) {
+        String msg = "Bad Request: invalid message format";
+        logger.logSevereWithTracker(trackingId, null, msg);
+        throw new NonRetryableApplicationException("Request body or message is Null.");
+      }
 
-            String requestJsonString = requestBody.getMessage().dataToUtf8String();
+      String requestJsonString = requestBody.getMessage().dataToUtf8String();
 
-            // remove any escape characters (e.g. from Terraform
-            requestJsonString = requestJsonString.replace("\\", "");
+      // remove any escape characters (e.g. from Terraform
+      requestJsonString = requestJsonString.replace("\\", "");
 
-            logger.logInfoWithTracker(trackingId, null, String.format("Received payload: %s", requestJsonString));
+      logger.logInfoWithTracker(
+          trackingId, null, String.format("Received payload: %s", requestJsonString));
 
-            configuratorRequest = gson.fromJson(requestJsonString, ConfiguratorRequest.class);
+      configuratorRequest = gson.fromJson(requestJsonString, ConfiguratorRequest.class);
 
-            trackingId = configuratorRequest.getTrackingId();
+      trackingId = configuratorRequest.getTrackingId();
 
-            logger.logInfoWithTracker(configuratorRequest.isDryRun(), trackingId, configuratorRequest.getTargetTable(), String.format("Parsed Request: %s", configuratorRequest.toString()));
+      logger.logInfoWithTracker(
+          configuratorRequest.isDryRun(),
+          trackingId,
+          configuratorRequest.getTargetTable(),
+          String.format("Parsed Request: %s", configuratorRequest.toString()));
 
-            backupPolicyService = new BackupPolicyServiceGCSImpl(environment.getGcsBackupPoliciesBucket());
+      backupPolicyService =
+          new BackupPolicyServiceGCSImpl(environment.getGcsBackupPoliciesBucket());
 
-            Configurator configurator = new Configurator(
-                    environment.toConfig(),
-                    new BigQueryServiceImpl(configuratorRequest.getTargetTable().getProject()),
-                    backupPolicyService,
-                    new PubSubServiceImpl(),
-                    new ResourceScannerImpl(),
-                    new GCSPersistentSetImpl(environment.getGcsFlagsBucket()),
-                    fallbackBackupPolicy,
-                    "configurator-flags",
-                    functionNumber
-            );
+      Configurator configurator =
+          new Configurator(
+              environment.toConfig(),
+              new BigQueryServiceImpl(configuratorRequest.getTargetTable().getProject()),
+              backupPolicyService,
+              new PubSubServiceImpl(),
+              new ResourceScannerImpl(),
+              new GCSPersistentSetImpl(environment.getGcsFlagsBucket()),
+              fallbackBackupPolicy,
+              "configurator-flags",
+              functionNumber);
 
-            configuratorResponse = configurator.execute(configuratorRequest, requestBody.getMessage().getMessageId());
+      configuratorResponse =
+          configurator.execute(configuratorRequest, requestBody.getMessage().getMessageId());
 
-            responseEntity = new ResponseEntity("Process completed successfully.", HttpStatus.OK);
-            isSuccess = true;
+      responseEntity = new ResponseEntity("Process completed successfully.", HttpStatus.OK);
+      isSuccess = true;
 
-        } catch (Exception e) {
+    } catch (Exception e) {
 
-            Tuple<ResponseEntity, Boolean> handlingResults  = ControllerExceptionHelper.handleException(
-                    e,
-                    logger,
-                    trackingId,
-                    configuratorRequest == null? null : configuratorRequest.getTargetTable()
-                    );
-            isSuccess = false;
-            responseEntity = handlingResults.x();
-            isRetryableError = handlingResults.y();
-            error = e;
+      Tuple<ResponseEntity, Boolean> handlingResults =
+          ControllerExceptionHelper.handleException(
+              e,
+              logger,
+              trackingId,
+              configuratorRequest == null ? null : configuratorRequest.getTargetTable());
+      isSuccess = false;
+      responseEntity = handlingResults.x();
+      isRetryableError = handlingResults.y();
+      error = e;
 
-        } finally {
+    } finally {
 
-            if (backupPolicyService != null) {
-                backupPolicyService.shutdown();
-            }
-        }
-
-        logger.logUnified(
-                configuratorRequest == null? null: configuratorRequest.isDryRun(),
-                functionNumber.toString(),
-                configuratorRequest == null? null: configuratorRequest.getRunId(),
-                configuratorRequest == null? null: configuratorRequest.getTrackingId(),
-                configuratorRequest == null? null : configuratorRequest.getTargetTable(),
-                configuratorRequest,
-                configuratorResponse,
-                isSuccess,
-                error,
-                isRetryableError
-        );
-
-        return responseEntity;
+      if (backupPolicyService != null) {
+        backupPolicyService.shutdown();
+      }
     }
 
-    public static void main(String[] args) {
-        SpringApplication.run(ConfiguratorController.class, args);
-    }
+    logger.logUnified(
+        configuratorRequest == null ? null : configuratorRequest.isDryRun(),
+        functionNumber.toString(),
+        configuratorRequest == null ? null : configuratorRequest.getRunId(),
+        configuratorRequest == null ? null : configuratorRequest.getTrackingId(),
+        configuratorRequest == null ? null : configuratorRequest.getTargetTable(),
+        configuratorRequest,
+        configuratorResponse,
+        isSuccess,
+        error,
+        isRetryableError);
+
+    return responseEntity;
+  }
+
+  public static void main(String[] args) {
+    SpringApplication.run(ConfiguratorController.class, args);
+  }
 }

--- a/services/configurator-app/src/main/java/com/google/cloud/pso/bq_snapshot_manager/configurator/ConfiguratorController.java
+++ b/services/configurator-app/src/main/java/com/google/cloud/pso/bq_snapshot_manager/configurator/ConfiguratorController.java
@@ -17,6 +17,7 @@
  */
 package com.google.cloud.pso.bq_snapshot_manager.configurator;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.cloud.Tuple;
 import com.google.cloud.pso.bq_snapshot_manager.entities.NonRetryableApplicationException;
 import com.google.cloud.pso.bq_snapshot_manager.entities.PubSubEvent;
@@ -27,9 +28,9 @@ import com.google.cloud.pso.bq_snapshot_manager.functions.f02_configurator.Confi
 import com.google.cloud.pso.bq_snapshot_manager.helpers.ControllerExceptionHelper;
 import com.google.cloud.pso.bq_snapshot_manager.helpers.LoggingHelper;
 import com.google.cloud.pso.bq_snapshot_manager.helpers.TrackingHelper;
-import com.google.cloud.pso.bq_snapshot_manager.services.backup_policy.BackupPolicyService;
 import com.google.cloud.pso.bq_snapshot_manager.services.backup_policy.BackupPolicyServiceGCSImpl;
 import com.google.cloud.pso.bq_snapshot_manager.services.bq.BigQueryServiceImpl;
+import com.google.cloud.pso.bq_snapshot_manager.services.backup_policy.BackupPolicyService;
 import com.google.cloud.pso.bq_snapshot_manager.services.pubsub.PubSubServiceImpl;
 import com.google.cloud.pso.bq_snapshot_manager.services.scan.ResourceScannerImpl;
 import com.google.cloud.pso.bq_snapshot_manager.services.set.GCSPersistentSetImpl;
@@ -60,14 +61,18 @@ public class ConfiguratorController {
 
     gson = new Gson();
     environment = new Environment();
-    logger =
-        new LoggingHelper(
+    logger = new LoggingHelper(
             ConfiguratorController.class.getSimpleName(),
             functionNumber,
             environment.getProjectId(),
-            environment.getApplicationName());
+            environment.getApplicationName()
+    );
 
-    logger.logInfoWithTracker(trackingId, null, "Will try to parse fallback backup policy..");
+    logger.logInfoWithTracker(
+            trackingId,
+            null,
+            "Will try to parse fallback backup policy.."
+    );
 
     // initializing in the constructor to fail the Cloud Run deployment
     // if the parsing failed. This is to avoid running the
@@ -77,17 +82,22 @@ public class ConfiguratorController {
       fallbackBackupPolicy = FallbackBackupPolicy.fromJson(environment.getBackupPolicyJson());
     } catch (Exception ex) {
       String msg =
-          String.format(
-              "Failed to parse one or more fallback backup policies. %s", ex.getMessage());
+              String.format(
+                      "Failed to parse one or more fallback backup policies. %s", ex.getMessage());
       logger.logSevereWithTracker(trackingId, null, msg);
       throw new NonRetryableApplicationException(msg);
     }
 
-    logger.logInfoWithTracker(trackingId, null, "Successfully parsed fallback backup policy");
+    logger.logInfoWithTracker(
+            trackingId,
+            null,
+            "Successfully parsed fallback backup policy"
+    );
   }
 
   @RequestMapping(value = "/", method = RequestMethod.POST)
   public ResponseEntity receiveMessage(@RequestBody PubSubEvent requestBody) {
+
 
     BackupPolicyService backupPolicyService = null;
 
@@ -97,13 +107,13 @@ public class ConfiguratorController {
     ConfiguratorResponse configuratorResponse = null;
     boolean isSuccess;
     Exception error = null;
-    boolean isRetryableError = false;
+    boolean isRetryableError= false;
 
     try {
 
       if (requestBody == null || requestBody.getMessage() == null) {
         String msg = "Bad Request: invalid message format";
-        logger.logSevereWithTracker(trackingId, null, msg);
+        logger.logSevereWithTracker(trackingId,null, msg);
         throw new NonRetryableApplicationException("Request body or message is Null.");
       }
 
@@ -112,24 +122,17 @@ public class ConfiguratorController {
       // remove any escape characters (e.g. from Terraform
       requestJsonString = requestJsonString.replace("\\", "");
 
-      logger.logInfoWithTracker(
-          trackingId, null, String.format("Received payload: %s", requestJsonString));
+      logger.logInfoWithTracker(trackingId, null, String.format("Received payload: %s", requestJsonString));
 
       configuratorRequest = gson.fromJson(requestJsonString, ConfiguratorRequest.class);
 
       trackingId = configuratorRequest.getTrackingId();
 
-      logger.logInfoWithTracker(
-          configuratorRequest.isDryRun(),
-          trackingId,
-          configuratorRequest.getTargetTable(),
-          String.format("Parsed Request: %s", configuratorRequest.toString()));
+      logger.logInfoWithTracker(configuratorRequest.isDryRun(), trackingId, configuratorRequest.getTargetTable(), String.format("Parsed Request: %s", configuratorRequest.toString()));
 
-      backupPolicyService =
-          new BackupPolicyServiceGCSImpl(environment.getGcsBackupPoliciesBucket());
+      backupPolicyService = new BackupPolicyServiceGCSImpl(environment.getGcsBackupPoliciesBucket());
 
-      Configurator configurator =
-          new Configurator(
+      Configurator configurator = new Configurator(
               environment.toConfig(),
               new BigQueryServiceImpl(configuratorRequest.getTargetTable().getProject()),
               backupPolicyService,
@@ -138,22 +141,22 @@ public class ConfiguratorController {
               new GCSPersistentSetImpl(environment.getGcsFlagsBucket()),
               fallbackBackupPolicy,
               "configurator-flags",
-              functionNumber);
+              functionNumber
+      );
 
-      configuratorResponse =
-          configurator.execute(configuratorRequest, requestBody.getMessage().getMessageId());
+      configuratorResponse = configurator.execute(configuratorRequest, requestBody.getMessage().getMessageId());
 
       responseEntity = new ResponseEntity("Process completed successfully.", HttpStatus.OK);
       isSuccess = true;
 
     } catch (Exception e) {
 
-      Tuple<ResponseEntity, Boolean> handlingResults =
-          ControllerExceptionHelper.handleException(
+      Tuple<ResponseEntity, Boolean> handlingResults  = ControllerExceptionHelper.handleException(
               e,
               logger,
               trackingId,
-              configuratorRequest == null ? null : configuratorRequest.getTargetTable());
+              configuratorRequest == null? null : configuratorRequest.getTargetTable()
+      );
       isSuccess = false;
       responseEntity = handlingResults.x();
       isRetryableError = handlingResults.y();
@@ -167,16 +170,17 @@ public class ConfiguratorController {
     }
 
     logger.logUnified(
-        configuratorRequest == null ? null : configuratorRequest.isDryRun(),
-        functionNumber.toString(),
-        configuratorRequest == null ? null : configuratorRequest.getRunId(),
-        configuratorRequest == null ? null : configuratorRequest.getTrackingId(),
-        configuratorRequest == null ? null : configuratorRequest.getTargetTable(),
-        configuratorRequest,
-        configuratorResponse,
-        isSuccess,
-        error,
-        isRetryableError);
+            configuratorRequest == null? null: configuratorRequest.isDryRun(),
+            functionNumber.toString(),
+            configuratorRequest == null? null: configuratorRequest.getRunId(),
+            configuratorRequest == null? null: configuratorRequest.getTrackingId(),
+            configuratorRequest == null? null : configuratorRequest.getTargetTable(),
+            configuratorRequest,
+            configuratorResponse,
+            isSuccess,
+            error,
+            isRetryableError
+    );
 
     return responseEntity;
   }


### PR DESCRIPTION
* When CSV exports are used in fallback and missing the delimiter and header configs the ConfiguratorController throws an exception at deployment type without a meaningful message. This PR logs a meaningful message about the missing fields but still throws an exception intentionally to fail the deployment instead of running with invalid fallback config
* Updated README to include the missing required fields for GCS CSV exports  